### PR TITLE
fix: Default value of MIS_PATH and PORTAL_PATH

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -130,7 +130,12 @@ def generate_path(property_data, system_module):
         else:
             return generate_path_common(property_data, False)
     else:
-        return ""
+        if system_module == "MIS":
+            return "/mis"
+        elif system_module == "PORTAL":
+            return "/"
+        else:
+            return ""
 
 
 def create_log_service():


### PR DESCRIPTION
fix： 处理当mis或者portal为false时，MIS_PATH和PORTAL_PATH的默认值不能为`""`问题。当mis为false时，MIS_PATH默认值为`/mis`，当portal为false时PORTAL_PATH默认值为`/`